### PR TITLE
Feature/support filtered folder collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
+tmp
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Netlify CMS Reader
 
-[![Build Status](https://travis-ci.org/tb/netlify-cms-reader.svg?branch=master)](https://travis-ci.org/tb/netlify-cms-reader)
-[![npm version](https://badge.fury.io/js/netlify-cms-reader.svg)](http://badge.fury.io/js/netlify-cms-reader)
-
 Read NetlifyCMS config and data.
 
 ## Basic usage

--- a/__tests__/__snapshots__/test-md.js.snap
+++ b/__tests__/__snapshots__/test-md.js.snap
@@ -26,3 +26,46 @@ Object {
   ],
 }
 `;
+
+exports[`reads md data with filtered folder collections 1`] = `
+Object {
+  "filtered_to_a_and_b": Array [
+    Object {
+      "content": "# Content with filter set to A or B",
+      "filter": Array [
+        "A",
+        "B",
+      ],
+      "title": "To be filtered to A or B",
+    },
+  ],
+  "filtered_to_c_and_d": Array [
+    Object {
+      "content": "# Content with filter set to C or D",
+      "filter": Array [
+        "D",
+        "C",
+      ],
+      "title": "To be filtered to C or D",
+    },
+  ],
+  "unfiltered": Array [
+    Object {
+      "content": "# Content with filter set to A or B",
+      "filter": Array [
+        "A",
+        "B",
+      ],
+      "title": "To be filtered to A or B",
+    },
+    Object {
+      "content": "# Content with filter set to C or D",
+      "filter": Array [
+        "D",
+        "C",
+      ],
+      "title": "To be filtered to C or D",
+    },
+  ],
+}
+`;

--- a/__tests__/__snapshots__/test-yaml.js.snap
+++ b/__tests__/__snapshots__/test-yaml.js.snap
@@ -25,3 +25,46 @@ Object {
   ],
 }
 `;
+
+exports[`reads yaml data with filtered folder collections 1`] = `
+Object {
+  "filtered_to_a_and_b": Array [
+    Object {
+      "content": "# Content with filter set to A or B",
+      "filter": Array [
+        "A",
+        "B",
+      ],
+      "title": "To be filtered to A or B",
+    },
+  ],
+  "filtered_to_c_and_d": Array [
+    Object {
+      "content": "# Content with filter set to C or D",
+      "filter": Array [
+        "D",
+        "C",
+      ],
+      "title": "To be filtered to C or D",
+    },
+  ],
+  "unfiltered": Array [
+    Object {
+      "content": "# Content with filter set to A or B",
+      "filter": Array [
+        "A",
+        "B",
+      ],
+      "title": "To be filtered to A or B",
+    },
+    Object {
+      "content": "# Content with filter set to C or D",
+      "filter": Array [
+        "D",
+        "C",
+      ],
+      "title": "To be filtered to C or D",
+    },
+  ],
+}
+`;

--- a/__tests__/md/config-with-filtered-folder-collections.yml
+++ b/__tests__/md/config-with-filtered-folder-collections.yml
@@ -1,0 +1,32 @@
+backend:
+  name: proxy
+  proxy_url: http://localhost:8081/api/v1
+  branch: master
+
+media_folder: static/uploads
+public_folder: /uploads
+
+collections:
+  - name: unfiltered
+    label: "Unfiltered"
+    folder: __tests__/md/filtered
+    fields:
+      - {label: Title, name: title, widget: string}
+      - {label: "Filter", name: filter, widget: select, multiple: true, options: ["A","B", "C", "D"]}
+      - {label: Content, name: content, widget: markdown}
+  - name: filtered_to_a_and_b
+    label: "Filtered to A and B"
+    folder: __tests__/md/filtered
+    filter: {field: "filter", value: ["A", "B"]}
+    fields:
+      - {label: Title, name: title, widget: string}
+      - {label: "Filter", name: filter, widget: select, multiple: true, options: ["A","B", "C", "D"]}
+      - {label: Content, name: content, widget: markdown}
+  - name: filtered_to_c_and_d
+    label: "Filtered to C and D"
+    folder: __tests__/md/filtered
+    filter: {field: "filter", value: ["C", "D"]}
+    fields:
+      - {label: Title, name: title, widget: string}
+      - {label: "Filter", name: filter, widget: select, multiple: true, options: ["A","B", "C", "D"]}
+      - {label: Content, name: content, widget: markdown}

--- a/__tests__/md/filtered/a.md
+++ b/__tests__/md/filtered/a.md
@@ -1,0 +1,7 @@
+---
+title: To be filtered to A or B
+filter:
+ - A
+ - B
+---
+# Content with filter set to A or B

--- a/__tests__/md/filtered/b.md
+++ b/__tests__/md/filtered/b.md
@@ -1,0 +1,7 @@
+---
+title: To be filtered to C or D
+filter: 
+  - D
+  - C
+---
+# Content with filter set to C or D

--- a/__tests__/test-md.js
+++ b/__tests__/test-md.js
@@ -5,3 +5,11 @@ test('reads md data', async () => {
   const data = await getData(config)
   expect(data).toMatchSnapshot()
 })
+
+test('reads md data with filtered folder collections', async () => {
+  const config = getConfig(
+    '__tests__/md/config-with-filtered-folder-collections.yml'
+  )
+  const data = await getData(config)
+  expect(data).toMatchSnapshot()
+})

--- a/__tests__/test-yaml.js
+++ b/__tests__/test-yaml.js
@@ -5,3 +5,11 @@ test('reads yaml data', async () => {
   const data = await getData(config)
   expect(data).toMatchSnapshot()
 })
+
+test('reads yaml data with filtered folder collections', async () => {
+  const config = getConfig(
+    '__tests__/yaml/config-with-filtered-folder-collections.yml'
+  )
+  const data = await getData(config)
+  expect(data).toMatchSnapshot()
+})

--- a/__tests__/yaml/config-with-filtered-folder-collections.yml
+++ b/__tests__/yaml/config-with-filtered-folder-collections.yml
@@ -1,0 +1,35 @@
+backend:
+  name: proxy
+  proxy_url: http://localhost:8081/api/v1
+  branch: master
+
+media_folder: static/uploads
+public_folder: /uploads
+
+collections:
+  - name: unfiltered
+    label: "Unfiltered"
+    folder: __tests__/yaml/filtered
+    format: yml
+    fields:
+      - {label: Title, name: title, widget: string}
+      - {label: "Filter", name: filter, widget: select, multiple: true, options: ["A","B","C","D"]}
+      - {label: "Content", name: content, widget: markdown}
+  - name: filtered_to_a_and_b
+    label: "Filtered to A and B"
+    folder: __tests__/yaml/filtered
+    format: yml
+    filter: {field: "filter", value: ["A", "B"]}
+    fields:
+      - {label: Title, name: title, widget: string}
+      - {label: "Filter", name: filter, widget: select, multiple: true, options: ["A","B","C","D"]}
+      - {label: "Content", name: content, widget: markdown}
+  - name: filtered_to_c_and_d
+    label: "Filtered to C and D"
+    folder: __tests__/yaml/filtered
+    format: yml
+    filter: {field: "filter", value:  ["C", "D"]}
+    fields:
+      - {label: Title, name: title, widget: string}
+      - {label: "Filter", name: filter, widget: select, multiple: true, options: ["A","B","C","D"]}
+      - {label: "Content", name: content, widget: markdown}

--- a/__tests__/yaml/filtered/a.yml
+++ b/__tests__/yaml/filtered/a.yml
@@ -1,0 +1,6 @@
+title: To be filtered to A or B
+filter:
+  - A
+  - B
+content: >-
+  # Content with filter set to A or B

--- a/__tests__/yaml/filtered/b.yml
+++ b/__tests__/yaml/filtered/b.yml
@@ -1,0 +1,6 @@
+title: To be filtered to C or D
+filter:
+  - D
+  - C
+content: >-
+  # Content with filter set to C or D

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ const fs = require('fs')
 const matter = require('gray-matter')
 const yaml = require('js-yaml')
 const globby = require('globby')
+const isEqual = require('lodash.isequal')
+const sortBy = require('lodash.sortby')
 
 const markdownLoad = s => {
   const { content, data } = matter(s)
@@ -14,13 +16,35 @@ const readFiles = pattern => globby.sync(pattern).map(readFile)
 
 const getConfig = filepath => yaml.safeLoad(fs.readFileSync(filepath, 'utf8'))
 
+const isEqualWithoutOrder = (a, b) =>
+  Array.isArray(a) && Array.isArray(b)
+    ? isEqual(sortBy(a), sortBy(b))
+    : isEqual(a, b)
+
+const filterFolder = (folder, format, field, value) => {
+  const unfiltered =
+    format === 'yml'
+      ? readFiles(`${folder}/*.yml`).map(yaml.safeLoad)
+      : readFiles(`${folder}/*.md`).map(markdownLoad)
+  return unfiltered.filter(object => isEqualWithoutOrder(object[field], value))
+}
+
 const getData = config =>
   config.collections.reduce((data, c) => {
     if (c.folder) {
-      data[c.name] =
-        c.format === 'yml'
-          ? readFiles(`${c.folder}/*.yml`).map(yaml.safeLoad)
-          : readFiles(`${c.folder}/*.md`).map(markdownLoad)
+      if (c.filter && c.filter.field && c.filter.value) {
+        data[c.name] = filterFolder(
+          c.folder,
+          c.format,
+          c.filter.field,
+          c.filter.value
+        )
+      } else {
+        data[c.name] =
+          c.format === 'yml'
+            ? readFiles(`${c.folder}/*.yml`).map(yaml.safeLoad)
+            : readFiles(`${c.folder}/*.md`).map(markdownLoad)
+      }
     }
 
     if (c.files) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-cms-reader",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1651,7 +1651,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1672,12 +1673,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1692,17 +1695,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1819,7 +1825,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1831,6 +1838,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1845,6 +1853,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1852,12 +1861,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1876,6 +1887,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1956,7 +1968,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1968,6 +1981,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2053,7 +2067,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2089,6 +2104,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2108,6 +2124,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2151,12 +2168,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3385,11 +3404,15 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "dependencies": {
     "globby": "*",
     "gray-matter": "*",
-    "js-yaml": "*"
+    "js-yaml": "*",
+    "lodash.isequal": "^4.5.0",
+    "lodash.sortby": "^4.7.0"
   },
   "devDependencies": {
     "jest": "^24.7.1",


### PR DESCRIPTION
netlify-cms-reader v1.0.4 returns filtered folder collections without performing the filtering on the actual collections.

(For filtered folder collections in Netlify CMS, see:
https://www.netlifycms.org/docs/collection-types/#filtered-folder-collections)

This commit implements the support of filtered folder collections

If a folder collection is filtered, then that collection is returned by applying the criteria configured in its `filter` property.

As the supported types for the filter `value` is *not* documented, this implementation accepts all possible types, so a filter with the setting `{field: "tags", value: ["latest", "most popular"]}`
*is* handled, despite the fact that the UI of Netlify CMS (at least with version 2.10.48) does *not* handle it while configuration for it is accepted.