### PR TITLE
feat: Support sortableFields in folder collections

### DIFF
--- a/__tests__/__snapshots__/test-md.js.snap
+++ b/__tests__/__snapshots__/test-md.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`honors first of the sortableField list 1`] = `
+Object {
+  "sortable": Array [
+    Object {
+      "content": "# Page With Index 1 Content",
+      "index": 1,
+      "title": "Page With Index 1",
+    },
+    Object {
+      "content": "# Page With Index 2 Content",
+      "index": 2,
+      "title": "Page With Index 2",
+    },
+  ],
+}
+`;
+
 exports[`reads md data 1`] = `
 Object {
   "layout": Object {

--- a/__tests__/__snapshots__/test-yaml.js.snap
+++ b/__tests__/__snapshots__/test-yaml.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`honors first of the sortableField list 1`] = `
+Object {
+  "sortable": Array [
+    Object {
+      "content": "# Page With Index 1 Content",
+      "index": 1,
+      "title": "Page With Index 1",
+    },
+    Object {
+      "content": "# Page With Index 2 Content",
+      "index": 2,
+      "title": "Page With Index 2",
+    },
+  ],
+}
+`;
+
 exports[`reads yaml data 1`] = `
 Object {
   "layout": Object {

--- a/__tests__/md/config-with-sortableField-in-folder-collections.yml
+++ b/__tests__/md/config-with-sortableField-in-folder-collections.yml
@@ -1,0 +1,17 @@
+backend:
+  name: proxy
+  proxy_url: http://localhost:8081/api/v1
+  branch: master
+
+media_folder: static/uploads
+public_folder: /uploads
+
+collections:
+  - name: sortable
+    label: "Sortable"
+    folder: __tests__/md/sortable
+    sortableFields: ["index", "title"]
+    fields:
+      - {label: Title, name: title, widget: string}
+      - {label: "Index", name: index, widget: number, valueType: int}
+      - {label: "Content", name: content, widget: markdown}

--- a/__tests__/md/sortable/sortable-a.md
+++ b/__tests__/md/sortable/sortable-a.md
@@ -1,0 +1,5 @@
+---
+title: Page With Index 2
+index: 2
+---
+# Page With Index 2 Content

--- a/__tests__/md/sortable/sortable-b.md
+++ b/__tests__/md/sortable/sortable-b.md
@@ -1,0 +1,5 @@
+---
+title: Page With Index 1
+index: 1
+---
+# Page With Index 1 Content

--- a/__tests__/test-md.js
+++ b/__tests__/test-md.js
@@ -13,3 +13,11 @@ test('reads md data with filtered folder collections', async () => {
   const data = await getData(config)
   expect(data).toMatchSnapshot()
 })
+
+test('honors first of the sortableField list', async () => {
+  const config = getConfig(
+    '__tests__/md/config-with-sortableField-in-folder-collections.yml'
+  )
+  const data = await getData(config)
+  expect(data).toMatchSnapshot()
+})

--- a/__tests__/test-yaml.js
+++ b/__tests__/test-yaml.js
@@ -13,3 +13,11 @@ test('reads yaml data with filtered folder collections', async () => {
   const data = await getData(config)
   expect(data).toMatchSnapshot()
 })
+
+test('honors first of the sortableField list', async () => {
+  const config = getConfig(
+    '__tests__/yaml/config-with-sortableField-in-folder-collections.yml'
+  )
+  const data = await getData(config)
+  expect(data).toMatchSnapshot()
+})

--- a/__tests__/yaml/config-with-sortableField-in-folder-collections.yml
+++ b/__tests__/yaml/config-with-sortableField-in-folder-collections.yml
@@ -1,0 +1,18 @@
+backend:
+  name: proxy
+  proxy_url: http://localhost:8081/api/v1
+  branch: master
+
+media_folder: static/uploads
+public_folder: /uploads
+
+collections:
+  - name: sortable
+    label: "Sortable"
+    folder: __tests__/yaml/sortable
+    format: yml
+    sortableFields: ["index", "title"]
+    fields:
+      - {label: Title, name: title, widget: string}
+      - {label: "Index", name: index, widget: number, valueType: int}
+      - {label: "Content", name: content, widget: markdown}

--- a/__tests__/yaml/sortable/sortable-a.yml
+++ b/__tests__/yaml/sortable/sortable-a.yml
@@ -1,0 +1,4 @@
+title: Page With Index 2
+index: 2
+content: >-
+  # Page With Index 2 Content

--- a/__tests__/yaml/sortable/sortable-b.yml
+++ b/__tests__/yaml/sortable/sortable-b.yml
@@ -1,0 +1,5 @@
+title: Page With Index 1
+index: 1
+content: >-
+  # Page With Index 1 Content
+

--- a/index.js
+++ b/index.js
@@ -31,19 +31,25 @@ const filterFolder = (folder, format, field, value) => {
 
 const getData = config =>
   config.collections.reduce((data, c) => {
+    let tmpData
     if (c.folder) {
       if (c.filter && c.filter.field && c.filter.value) {
-        data[c.name] = filterFolder(
+        tmpData = filterFolder(
           c.folder,
           c.format,
           c.filter.field,
           c.filter.value
         )
       } else {
-        data[c.name] =
+        tmpData =
           c.format === 'yml'
             ? readFiles(`${c.folder}/*.yml`).map(yaml.safeLoad)
             : readFiles(`${c.folder}/*.md`).map(markdownLoad)
+      }
+      if (c.sortableFields && c.sortableFields[0]) {
+        data[c.name] = sortBy(tmpData, c.sortableFields[0])
+      } else {
+        data[c.name] = tmpData.slice()
       }
     }
 


### PR DESCRIPTION
netlify-cms-reader v1.0.4 returns folder collections with
sortableFields set without sorting the actual collections.

For the sortableFields setting in Netlify CMS, see:
https://www.netlifycms.org/docs/configuration-options/#sortablefields

This commit implements the support of the sortableFields setting for
folder collections.

If a folder collection has a sortableFields setting, then that
collection is returned by sorting it in increasing order based on
the first element in the sortableFields array. So if a collection
have a sortableFields setting like `['latest', 'most popular']` then
the collection will be returned with the items sorted by the values of
their `latest` field in increasing order.